### PR TITLE
Use VZ presets and override existing defaults

### DIFF
--- a/Packages/com.jaimecamacho.unitypreset/Editor/DefaultPresetInstaller.cs
+++ b/Packages/com.jaimecamacho.unitypreset/Editor/DefaultPresetInstaller.cs
@@ -1,6 +1,5 @@
 using System;
-using System.Collections;
-using System.Reflection;
+using System.Collections.Generic;
 using UnityEditor;
 using UnityEditor.Presets;
 using UnityEngine;
@@ -26,15 +25,22 @@ internal static class DefaultPresetInstaller
   
     static void RegisterTexturePresets()
     {
-        AddPreset<TextureImporter>("Packages/com.jaimecamacho.unitypreset/Presets/Importers/Textures/TI_Albedo.preset", "");
-        AddPreset<TextureImporter>("Packages/com.jaimecamacho.unitypreset/Presets/Importers/Textures/TI_Normal.preset", "name:*_N*");
-        AddPreset<TextureImporter>("Packages/com.jaimecamacho.unitypreset/Presets/Importers/Textures/TI_Lightmap.preset", "path:*/Lightmaps/*");
+        AddPreset<TextureImporter>(
+            "Packages/com.jaimecamacho.unitypreset/Presets/Importers/Textures/VZ_Textures.preset",
+            "glob:\"2-Art/1-3D/**/*\"");
+        AddPreset<TextureImporter>(
+            "Packages/com.jaimecamacho.unitypreset/Presets/Importers/Textures/VZ_Normal.preset",
+            "glob:\"*_Normal.*\"");
     }
 
     static void RegisterModelPresets()
     {
-        AddPreset<ModelImporter>("Packages/com.jaimecamacho.unitypreset/Presets/Importers/Models/MI_FBX_Static.preset", "");
-        AddPreset<ModelImporter>("Packages/com.jaimecamacho.unitypreset/Presets/Importers/Models/MI_FBX_Animated.preset", "label:animated");
+        AddPreset<ModelImporter>(
+            "Packages/com.jaimecamacho.unitypreset/Presets/Importers/Models/VZ_FBX_Static.preset",
+            "glob:\"2-Art/1-3D/**/*\"");
+        AddPreset<ModelImporter>(
+            "Packages/com.jaimecamacho.unitypreset/Presets/Importers/Models/VZ_FBX_Animated.preset",
+            "glob:\"2-Art/1-3D/**/*\"");
     }
 
     static void AddPreset<T>(string presetPath, string filter) where T : AssetImporter
@@ -46,41 +52,26 @@ internal static class DefaultPresetInstaller
             return;
         }
 
-        var type = typeof(T);
-        var presetManagerType = typeof(Preset).Assembly.GetType("UnityEditor.Presets.PresetManager");
-        if (presetManagerType == null)
-        {
-            Debug.LogWarning("[UnityPreset] PresetManager type not found");
-            return;
-        }
+        var importerType = typeof(T);
+        var presetType = PresetType.GetPresetTypeFromType(importerType);
+        var defaults = new List<DefaultPreset>(Preset.GetDefaultPresetsForType(presetType));
 
-        var getDefaults = presetManagerType.GetMethod("GetDefaultPresetsForType", BindingFlags.Static | BindingFlags.Public);
-        var addDefault = presetManagerType.GetMethod("AddDefaultPreset", BindingFlags.Static | BindingFlags.Public);
-        if (getDefaults == null || addDefault == null)
+        var index = defaults.FindIndex(d => d.filter == filter);
+        if (index >= 0)
         {
-            Debug.LogWarning("[UnityPreset] PresetManager methods not found");
-            return;
-        }
-
-        var defaults = (IEnumerable)getDefaults.Invoke(null, new object[] { type });
-        foreach (var entry in defaults)
-        {
-            var entryType = entry.GetType();
-            var presetField = entryType.GetField("preset");
-            var filterField = entryType.GetField("filter");
-            if (presetField == null || filterField == null)
-                continue;
-
-            var existingPreset = presetField.GetValue(entry) as Preset;
-            var existingFilter = filterField.GetValue(entry) as string;
-            if (existingPreset == preset && existingFilter == filter)
+            var existing = defaults[index];
+            if (existing.preset == preset)
             {
-                Debug.Log($"[UnityPreset] Preset {preset.name} already registered for {type.Name} with filter '{filter}'");
+                Debug.Log($"[UnityPreset] Preset {preset.name} already registered for {importerType.Name} with filter '{filter}'");
                 return;
             }
+
+            defaults.RemoveAt(index);
+            Debug.Log($"[UnityPreset] Removed preset {existing.preset.name} for {importerType.Name} with filter '{existing.filter}'");
         }
 
-        addDefault.Invoke(null, new object[] { type, filter, preset });
-        Debug.Log($"[UnityPreset] Registered preset {preset.name} for {type.Name} with filter '{filter}'");
+        defaults.Add(new DefaultPreset(filter, preset));
+        Preset.SetDefaultPresetsForType(presetType, defaults.ToArray());
+        Debug.Log($"[UnityPreset] Registered preset {preset.name} for {importerType.Name} with filter '{filter}'");
     }
 }

--- a/Packages/com.jaimecamacho.unitypreset/README.md
+++ b/Packages/com.jaimecamacho.unitypreset/README.md
@@ -5,24 +5,22 @@ Paquete con Presets y script de instalación automática para acelerar la import
 ## Presets incluidos
 
 ### Texturas
-- **TI_Albedo**: textura estándar con sRGB y mipmaps.
-- **TI_Normal**: mapa de normales con sRGB desactivado.
-- **TI_Lightmap**: lightmap en espacio lineal sin mipmaps.
+- **VZ_Textures**: ajustes generales para texturas.
+- **VZ_Normal**: configuración para mapas de normales.
 
 ### Modelos FBX
-- **MI_FBX_Static**: desactiva la importación de animaciones.
-- **MI_FBX_Animated**: activa la importación de animaciones.
+- **VZ_FBX_Static**: desactiva la importación de animaciones.
+- **VZ_FBX_Animated**: activa la importación de animaciones.
 
 ## Instalación automática
 Al importar el paquete, el script `DefaultPresetInstaller` añade las siguientes entradas al Preset Manager:
 
 | Tipo | Filtro | Preset |
 | --- | --- | --- |
-| `TextureImporter` | *(sin filtro)* | TI_Albedo |
-| `TextureImporter` | `name:*_N*` | TI_Normal |
-| `TextureImporter` | `path:*/Lightmaps/*` | TI_Lightmap |
-| `ModelImporter` | `label:static` | MI_FBX_Static |
-| `ModelImporter` | `label:animated` | MI_FBX_Animated |
+| `TextureImporter` | `glob:"2-Art/1-3D/**/*"` | VZ_Textures |
+| `TextureImporter` | `glob:"*_Normal.*"` | VZ_Normal |
+| `ModelImporter` | `glob:"2-Art/1-3D/**/*"` | VZ_FBX_Static |
+| `ModelImporter` | `glob:"2-Art/1-3D/**/*"` | VZ_FBX_Animated |
 
 Puedes modificar los filtros desde **Project Settings > Preset Manager** según tu organización de assets.
 


### PR DESCRIPTION
## Summary
- register VZ texture and model presets with updated glob filters
- replace existing Preset Manager entries when installing defaults
- load and save default presets using PresetType to avoid type conversion compile errors
- resolve constructor mismatch by obtaining PresetType from importer Type

## Testing
- `dotnet test` *(fails: command not found: dotnet)*


------
https://chatgpt.com/codex/tasks/task_b_68b9e3a448208326bdbe99626fda70d5