### PR TITLE
Fix preset type argument for default ModelImporter presets

### DIFF
--- a/Assets/4-Presets/Editor/VZ_PresetManagerApplier.cs
+++ b/Assets/4-Presets/Editor/VZ_PresetManagerApplier.cs
@@ -9,7 +9,7 @@ public static class VZ_PresetManagerApplier
     private static void ApplyPresetManagerPresets()
     {
         // Fetch default presets for ModelImporter from Preset Manager
-        var defaults = Preset.GetDefaultPresetsForType(new PresetType(typeof(ModelImporter)));
+        var defaults = Preset.GetDefaultPresetsForType(new PresetType("ModelImporter"));
         if (defaults == null || defaults.Length == 0)
         {
             EditorUtility.DisplayDialog("VZ Presets", "No default presets found for ModelImporter.", "OK");


### PR DESCRIPTION
## Summary
- fetch default ModelImporter presets using string-based `PresetType`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c0257138488326a86e0f9691b66b25