### PR TITLE
fix: resolve preset type retrieval

### DIFF
--- a/Assets/4-Presets/Editor/VZ_PresetManagerApplier.cs
+++ b/Assets/4-Presets/Editor/VZ_PresetManagerApplier.cs
@@ -1,4 +1,7 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using UnityEditor;
 using UnityEditor.Presets;
 using UnityEngine;
@@ -8,8 +11,8 @@ public static class VZ_PresetManagerApplier
     [MenuItem("Tools/VZ Presets/Apply VZ presets")]
     private static void ApplyPresetManagerPresets()
     {
-        // Fetch default presets for ModelImporter from Preset Manager
-        var defaults = Preset.GetDefaultPresetsForType(new PresetType("ModelImporter"));
+        // Fetch default presets for ModelImporter from Preset Manager using reflection
+        var defaults = GetDefaultPresetsForModelImporter();
         if (defaults == null || defaults.Length == 0)
         {
             EditorUtility.DisplayDialog("VZ Presets", "No default presets found for ModelImporter.", "OK");
@@ -67,5 +70,65 @@ public static class VZ_PresetManagerApplier
         int end = filter.IndexOf('\"', start);
         if (end < 0) return null;
         return filter.Substring(start, end - start);
+    }
+
+    // ---------------------------------------------------------------
+    //  Reflection helpers to support multiple Unity versions
+    // ---------------------------------------------------------------
+    private static Preset[] GetDefaultPresetsForModelImporter()
+    {
+        var presetTypeType = typeof(Preset).Assembly.GetType("UnityEditor.Presets.PresetType");
+        if (presetTypeType == null)
+            return null;
+
+        var presetTypeInstance = CreatePresetTypeForModelImporter(presetTypeType);
+        if (presetTypeInstance != null)
+        {
+            var method = typeof(Preset).GetMethod("GetDefaultPresetsForType",
+                BindingFlags.Public | BindingFlags.Static,
+                null,
+                new[] { presetTypeType },
+                null);
+
+            if (method != null)
+                return method.Invoke(null, new[] { presetTypeInstance }) as Preset[];
+        }
+
+        var methodType = typeof(Preset).GetMethod("GetDefaultPresetsForType",
+            BindingFlags.Public | BindingFlags.Static,
+            null,
+            new[] { typeof(Type) },
+            null);
+
+        if (methodType != null)
+            return methodType.Invoke(null, new object[] { typeof(ModelImporter) }) as Preset[];
+
+        return null;
+    }
+
+    private static object CreatePresetTypeForModelImporter(Type presetTypeType)
+    {
+        var ctorType = presetTypeType.GetConstructor(new[] { typeof(Type) });
+        if (ctorType != null)
+            return ctorType.Invoke(new object[] { typeof(ModelImporter) });
+
+        var ctorObj = presetTypeType.GetConstructor(new[] { typeof(UnityEngine.Object) });
+        if (ctorObj != null)
+        {
+            var anyModelGuid = AssetDatabase.FindAssets("t:Model", new[] { "Assets" }).FirstOrDefault();
+            if (!string.IsNullOrEmpty(anyModelGuid))
+            {
+                var path = AssetDatabase.GUIDToAssetPath(anyModelGuid);
+                var importer = AssetImporter.GetAtPath(path) as ModelImporter;
+                if (importer != null)
+                    return ctorObj.Invoke(new object[] { importer });
+            }
+        }
+
+        var ctorString = presetTypeType.GetConstructor(new[] { typeof(string) });
+        if (ctorString != null)
+            return ctorString.Invoke(new object[] { "ModelImporter" });
+
+        return null;
     }
 }


### PR DESCRIPTION
## Summary
- handle default ModelImporter presets via reflection to avoid constructor mismatches

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c03bf70b748326b287dce8fb1935a3